### PR TITLE
Upgrade redux saga for working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # redux-saga-beginner-tutorial
-Companion Repo for [Redux/Redux-saga beginner tutorial](http://yelouafi.github.io/redux-saga/docs/introduction/BeginnerTutorial.html)
+Companion Repo for [Redux/Redux-saga beginner tutorial](https://github.com/redux-saga/redux-saga/blob/master/docs/introduction/BeginnerTutorial.md)
 
 # Instructions
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "redux": "^3.3.1",
-    "redux-saga": "^0.10.4"
+    "redux-saga": "^0.14.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",

--- a/sagas.js
+++ b/sagas.js
@@ -1,5 +1,5 @@
-import { delay, takeEvery } from 'redux-saga'
-import { call, put } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { call, put, takeEvery } from 'redux-saga/effects'
 
 export function* helloSaga() {
   console.log('Hello Saga!')
@@ -11,7 +11,7 @@ export function* incrementAsync() {
 }
 
 export function* watchIncrementAsync() {
-  yield* takeEvery('INCREMENT_ASYNC', incrementAsync)
+  yield takeEvery('INCREMENT_ASYNC', incrementAsync)
 }
 
 // single entry point to start all Sagas at once


### PR DESCRIPTION
- Upgrade redux-saga to v0.14.0 so that the code in the tutorial works. The reason it does not work is that the tutorial has been updated to use takeEvery from `'redux-saga/effects'` that does not exist in v0.10.4.
- Fix the broken link to the beginner tutorial.
- Fix the working example in the `sagas` branch to use takeEvery from `'redux-saga/effects'` and move from `yield*` to `yield`.