### PR TITLE
sagas branch: upd deps to 2018-06-20

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["env", "react"]
 }

--- a/Counter.js
+++ b/Counter.js
@@ -1,5 +1,6 @@
 /*eslint-disable no-unused-vars */
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 const Counter = ({ value, onIncrement, onDecrement, onIncrementAsync }) =>
       <div>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import "babel-polyfill"
+import 'babel-polyfill'
 
 import React from 'react'
 import ReactDOM from 'react-dom'

--- a/package.json
+++ b/package.json
@@ -14,22 +14,22 @@
   "author": "Yassine ELOUAFI <yelouafi@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "6.3.14",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
-    "redux": "^3.3.1",
-    "redux-saga": "^0.14.0"
+    "babel-polyfill": "^6.26.0",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "redux": "^4.0.0",
+    "redux-saga": "^0.16.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.18",
-    "babel-core": "6.4.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
-    "babel-preset-stage-2": "^6.1.18",
-    "babelify": "^7.2.0",
-    "browserify": "^13.0.0",
-    "budo": "^8.0.4",
-    "tap-spec": "^4.1.1",
-    "tape": "^4.2.2"
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "babelify": "^8.0.0",
+    "browserify": "^16.2.2",
+    "budo": "^11.3.0",
+    "tap-spec": "^5.0.0",
+    "tape": "^4.9.1"
   }
 }


### PR DESCRIPTION
Updates to latest React practice:
* `React.PropTypes` was removed, and is now available in the `prop-types` package

Resolves these warnings during `npm install` (or `yarn install`):
* Deprecation of `babel-preset-es2015` and `babel-preset-stage-2` in favor of `babel-preset-env`
  > npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
* RegExp DoS issue in `babel-core > minimatch`
  > npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue