### PR TITLE
Fix wrong entrypoint in package.json that would cause some environments to crash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-saga-beginner-tutorial",
   "version": "0.0.0",
   "description": "Redux Saga beginner tutorial",
-  "main": "lib/index.js",
+  "main": "main.js",
   "scripts": {
     "test": "babel-node sagas.spec.js | tap-spec",
     "start": "budo main.js:build.js --dir ./ --verbose  --live -- -t babelify"


### PR DESCRIPTION
The original repository cannot be cloned in https://codesandbox.io because of missing `lib/index.js` file.

The fix is to change `main` field to point to the right file.